### PR TITLE
Fix duplicating prefixes on branch switch or manual activation of "Update Commit Message"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,19 +43,31 @@ function updateCommitMessage(repo: Repository) {
 }
 
 function getCommitMessage(branch: string, currentMessage: string, config: ExtensionConfig): string {
-	if (!config.commitMessagePrefixPattern.test(branch)) {
-		return currentMessage;
-	}
+    if (!config.commitMessagePrefixPattern.test(branch)) {
+        return currentMessage;
+    }
+    const prefixMatch = branch.match(config.commitMessagePrefixPattern);
+    if (!prefixMatch) {
+        return currentMessage;
+    }
+    const prefix = prefixMatch[1];
 
-	const prefixMatch = branch.match(config.commitMessagePrefixPattern);
-	if (!prefixMatch) { return currentMessage; }
+    if (currentMessage) {
+        const prefixOldBranchMatch = currentMessage.match(config.commitMessagePrefixPattern);
+        if (prefixOldBranchMatch) {
+            const prefixOldBranch = prefixOldBranchMatch[1]
+            if (prefix != prefixOldBranch) {
+                return currentMessage.replace(prefixOldBranch, prefix)
+            } else {
+                return currentMessage
+            }
+        }
+    }
 
-	const prefix = prefixMatch[1];
-	const formattedMessage = config.commitMessageFormat
-		.replace('${prefix}', prefix)
-		.replace('${message}', currentMessage);
-
-	return formattedMessage;
+    const formattedMessage = config.commitMessageFormat
+        .replace('${prefix}', prefix)
+        .replace('${message}', currentMessage);
+    return formattedMessage;
 }
 
 


### PR DESCRIPTION
*If the branch is switched - the new prefix from the new branch will replace the old prefix in the commit message 
(Before: Every branch switch, a new prefix is added: [XX-777] [XX-555] Sample Commit Message)

*If the branch is not switched and the prefix is already in the commit message - there is no change in the commit message
(Before: Every manual activation, a new prefix is added: [XX-777] [XX-777] Sample Commit Message)

*If "Update Commit Message" is activated manually and the prefix does not match with the branch - the prefix is changed to match the branch
(Before: Every manual activation, a new prefix is added: [XX-777] [XX-777] Sample Commit Message)